### PR TITLE
auth: fail-closed when BIRDMUG_JWT_SECRET is missing (closes #4)

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,10 +14,28 @@ const BUGFAIRY_URL = process.env.BUGFAIRY_URL || 'https://bugs.birdmug.com';
 const MATTERMOST_WEBHOOK_URL = process.env.MATTERMOST_WEBHOOK_URL || '';
 const PUBLIC_DIR = path.join(__dirname, 'public');
 
-// Fail hard if JWT secret is missing in production
-if (!JWT_SECRET && process.env.NODE_ENV === 'production') {
-  logger.error('BIRDMUG_JWT_SECRET is required in production');
-  process.exit(1);
+// Explicit opt-in for running locally without auth. Never set this in prod.
+const DEV_UNSAFE_OPEN_AUTH = process.env.DEV_UNSAFE_OPEN_AUTH === '1';
+
+// Fail-closed at boot: a missing JWT secret must not silently open the portal.
+// Either the operator has a real secret, OR they explicitly opted into open mode.
+if (!JWT_SECRET) {
+  if (DEV_UNSAFE_OPEN_AUTH) {
+    logger.warn(
+      '='.repeat(70) + '\n' +
+      'BirdMug Portal running with NO AUTH (DEV_UNSAFE_OPEN_AUTH=1).\n' +
+      'This must be LOCAL DEV ONLY. Any caller can hit every admin endpoint.\n' +
+      'Set BIRDMUG_JWT_SECRET from Doppler (birdmug-studios/prd) for any deploy.\n' +
+      '='.repeat(70)
+    );
+  } else {
+    logger.error(
+      'BIRDMUG_JWT_SECRET is not set. Refusing to start with silent open auth. ' +
+      'Pull the secret from Doppler (birdmug-studios/prd), or set ' +
+      'DEV_UNSAFE_OPEN_AUTH=1 explicitly for local dev.'
+    );
+    process.exit(1);
+  }
 }
 
 // SSH prefix for local dev (run commands on Toshi remotely)
@@ -215,7 +233,9 @@ app.use(express.static(PUBLIC_DIR));
 // ── Auth middleware ────────────────────────────────────────────────
 
 function requireAuth(req, res, next) {
-  if (!JWT_SECRET) return next(); // Auth disabled in dev (production exits at startup)
+  // Dev-only escape hatch: only bypass auth when the operator explicitly set
+  // DEV_UNSAFE_OPEN_AUTH=1 at boot. Otherwise the server already exited above.
+  if (!JWT_SECRET && DEV_UNSAFE_OPEN_AUTH) return next();
   const token = (req.headers.authorization || '').replace('Bearer ', '').trim()
     || req.query.token || '';
   if (!token) return res.status(401).json({ error: 'Not authenticated' });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -45,6 +45,9 @@ before(async () => {
   delete process.env.SSH_HOST;
   delete process.env.MATTERMOST_WEBHOOK_URL;
   process.env.NODE_ENV = 'test';
+  // These tests exercise the no-auth dev-mode path; server.js now requires an
+  // explicit opt-in so an unconfigured prod deploy can't silently open auth.
+  process.env.DEV_UNSAFE_OPEN_AUTH = '1';
 
   // Require the app module — server.js starts listening on require,
   // so we need to override PORT to use a dynamic port.


### PR DESCRIPTION
## Summary

Fixes #4. `requireAuth()` silently called `next()` when `JWT_SECRET` was missing. Production already exited at boot if the secret was missing, but dev mode was open with no warning, and the code path itself (\`if (!JWT_SECRET) return next()\`) was an accident-magnet.

## Changes

- **`server.js`** — two-layer fail-closed:
  1. At boot: if \`BIRDMUG_JWT_SECRET\` is missing, exit with a clear error unless \`DEV_UNSAFE_OPEN_AUTH=1\` is explicitly set. Prior behavior only exited when \`NODE_ENV=production\`.
  2. In requireAuth: the bypass branch is now gated on \`DEV_UNSAFE_OPEN_AUTH\`, not just the missing secret.
- Multi-line warning banner when the dev bypass is active.

## Test plan

- [x] No secret, no \`DEV_UNSAFE_OPEN_AUTH\` → exits on boot with clear message.
- [x] \`DEV_UNSAFE_OPEN_AUTH=1\`, no secret → starts, warning banner logged, auth bypassed.
- [x] Normal prod (secret set) → unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)