### PR TITLE
auth: reject JWTs from query string, header only (closes #5)

### DIFF
--- a/server.js
+++ b/server.js
@@ -236,8 +236,9 @@ function requireAuth(req, res, next) {
   // Dev-only escape hatch: only bypass auth when the operator explicitly set
   // DEV_UNSAFE_OPEN_AUTH=1 at boot. Otherwise the server already exited above.
   if (!JWT_SECRET && DEV_UNSAFE_OPEN_AUTH) return next();
-  const token = (req.headers.authorization || '').replace('Bearer ', '').trim()
-    || req.query.token || '';
+  // Tokens via query params leak into access logs, Referer headers, browser
+  // history, and link shares. Authorization header only.
+  const token = (req.headers.authorization || '').replace('Bearer ', '').trim();
   if (!token) return res.status(401).json({ error: 'Not authenticated' });
   try {
     // Portal accepts any logged-in BirdMug user — every token carries the


### PR DESCRIPTION
## Summary

Fixes #5. \`requireAuth\` in \`server.js\` accepted tokens via \`req.query.token\`. Query params leak into access logs, Referer headers, browser history, and any shared link — extending the blast radius of a leaked URL to a valid session.

## Change

- **\`server.js\`** — dropped \`|| req.query.token || ''\` from \`requireAuth\`. Authorization header only.
- Verified no in-repo callers used the query pattern.

## Test plan

- [x] \`Authorization: Bearer <t>\` → unchanged behavior.
- [x] \`?token=<t>\` → 401 (previously 200).
- [x] Existing tests should still pass (none used the query form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)