### PR TITLE
api: escape user input for Mattermost in /api/request-access (closes #1)

### DIFF
--- a/server.js
+++ b/server.js
@@ -401,13 +401,14 @@ const accessRequestLimiter = rateLimit({ windowMs: 60 * 60 * 1000, max: 3 });
 // webhook with a megabyte of junk.
 function escapeForMattermostCell(value) {
   const s = String(value ?? '').slice(0, 500);
-  // Strip control chars + newlines, replace with space
-  const noCtrl = s.replace(/[\r\n\t\x00-\x1F\x7F]+/g, ' ');
+  // Strip control chars + newlines, replace with space.
+  // eslint-disable-next-line no-control-regex
+  const noCtrl = s.replace(/[\r\n\t -]+/g, ' ');
   // Escape Markdown-meaningful chars + `|` (Mattermost table separator) and
   // `@`/`#` to neuter @here/@channel and channel links.
   return noCtrl
     .replace(/\\/g, '\\\\')
-    .replace(/([|`*_~\[\](){}#@<>])/g, '\\$1')
+    .replace(/([|`*_~[\](){}#@<>])/g, '\\$1')
     .trim() || '(empty)';
 }
 

--- a/server.js
+++ b/server.js
@@ -395,15 +395,61 @@ app.get('/api/bugs', requireAuth, async (req, res) => {
 
 // Access request — notifies operator for approval
 const accessRequestLimiter = rateLimit({ windowMs: 60 * 60 * 1000, max: 3 });
+// Escape Mattermost Markdown so user-supplied values can't inject links,
+// mentions, bold/italic, code fences, pipes (which break table columns), or
+// newlines (which break table rows). Clamp length so someone can't spam the
+// webhook with a megabyte of junk.
+function escapeForMattermostCell(value) {
+  const s = String(value ?? '').slice(0, 500);
+  // Strip control chars + newlines, replace with space
+  const noCtrl = s.replace(/[\r\n\t\x00-\x1F\x7F]+/g, ' ');
+  // Escape Markdown-meaningful chars + `|` (Mattermost table separator) and
+  // `@`/`#` to neuter @here/@channel and channel links.
+  return noCtrl
+    .replace(/\\/g, '\\\\')
+    .replace(/([|`*_~\[\](){}#@<>])/g, '\\$1')
+    .trim() || '(empty)';
+}
+
+// Simple shape validation before anything reaches the Mattermost webhook.
+const ACCESS_REQUEST_MAX_LEN = 300;
+function validateAccessField(label, value, required = true) {
+  if (value == null || String(value).trim() === '') {
+    return required ? `${label} is required.` : null;
+  }
+  if (String(value).length > ACCESS_REQUEST_MAX_LEN) {
+    return `${label} is too long (max ${ACCESS_REQUEST_MAX_LEN} chars).`;
+  }
+  return null;
+}
+
 app.post('/api/request-access', accessRequestLimiter, async (req, res) => {
   const { name, contact, reason } = req.body || {};
-  if (!name || !contact) {
-    return res.status(400).json({ error: 'Name and contact are required.' });
+
+  const errors = [
+    validateAccessField('Name', name),
+    validateAccessField('Contact', contact),
+    validateAccessField('Reason', reason, false),
+  ].filter(Boolean);
+  if (errors.length) {
+    return res.status(400).json({ error: errors.join(' ') });
   }
 
-  const message = `**Portal Access Request**\n| Field | Value |\n|---|---|\n| Name | ${name} |\n| Contact | ${contact} |\n| Reason | ${reason || 'Not provided'} |\n| Time | ${new Date().toISOString()} |`;
+  const safeName = escapeForMattermostCell(name);
+  const safeContact = escapeForMattermostCell(contact);
+  const safeReason = escapeForMattermostCell(reason || 'Not provided');
+  const timestamp = new Date().toISOString();
 
-  logger.info('Access request received', { name, contact, reason });
+  const message =
+    '**Portal Access Request**\n' +
+    '| Field | Value |\n' +
+    '|---|---|\n' +
+    `| Name | ${safeName} |\n` +
+    `| Contact | ${safeContact} |\n` +
+    `| Reason | ${safeReason} |\n` +
+    `| Time | ${timestamp} |`;
+
+  logger.info('Access request received', { name: safeName, contact: safeContact });
 
   if (MATTERMOST_WEBHOOK_URL) {
     try {


### PR DESCRIPTION
## Summary

Fixes #1. \`/api/request-access\` interpolated user-supplied \`name\`, \`contact\`, \`reason\` directly into a Mattermost Markdown table. Attacker could inject fake \`@channel\` mentions, phishing links, Markdown formatting, or break out of the table via \`|\` / newlines.

## Change

- **\`escapeForMattermostCell\`**: escapes Markdown meta-chars, pipe (\`|\`), \`@\`, \`#\`, strips control chars / newlines, clamps length.
- **\`validateAccessField\`**: up-front length check (300 char max) + required-field validation. Malformed requests 400 before anything reaches the webhook.
- Preserved the existing 200/400 response shape.

## Test plan

- [x] Normal submission (short plain text) → 200, clean Mattermost card.
- [x] Malicious inputs (\`[click](http://evil)\`, \`@channel\`, pipes, newlines) → 200 but rendered literally.
- [x] Missing \`name\` → 400 with validation message.
- [x] 500-char \`name\` → 400 with length error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)