### PR TITLE
gitignore: exclude .env + credentials + IDE droppings (closes #2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
 node_modules/
+
+# Secrets — live in Doppler (birdmug-portal/prd), never on disk
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+credentials.json
+
+# OS / IDE
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/


### PR DESCRIPTION
Closes #2. Adds `.env`, `.env.*` (with `!.env.example` escape), `*.pem`, `*.key`, `credentials.json`, and OS/IDE junk to .gitignore. Doppler stays source of truth (birdmug-portal/prd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)