### PR TITLE
compose: proxy Docker API instead of mounting raw socket (closes #3)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,26 @@
 services:
+  # ── Docker API proxy ──
+  # Restricts Docker API access to read-only container/image/info endpoints.
+  # Mounting /var/run/docker.sock directly into the portal would let a
+  # compromised portal exec into any container, create new ones, read all
+  # env vars, etc. docker-socket-proxy (tecnativa) whitelists only what's
+  # needed: `docker ps` -equivalent calls over an HTTP shim, read-only.
+  docker_socket_proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    container_name: portal_docker_socket_proxy
+    restart: unless-stopped
+    environment:
+      # 1 = allow, 0 = deny. Default is all 0; we only allow what the portal reads.
+      CONTAINERS: 1
+      IMAGES: 1
+      INFO: 1
+      # Everything else (EXEC, POST, VOLUMES, SERVICES, SWARM, SECRETS, etc.)
+      # stays denied. Proxy returns 403 on those endpoints.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - portal_net
+
   # ── Production ──
   portal-prod:
     build: .
@@ -6,16 +28,18 @@ services:
     container_name: birdmug_portal
     profiles: ["prod"]
     restart: unless-stopped
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    group_add:
-      - "111"
+    depends_on:
+      - docker_socket_proxy
+    networks:
+      - portal_net
     environment:
       - PORT=${PORT}
       - NODE_ENV=production
       - BIRDMUG_JWT_SECRET=${BIRDMUG_JWT_SECRET}
       - BUGFAIRY_URL=${BUGFAIRY_URL}
       - MATTERMOST_WEBHOOK_URL=${MATTERMOST_WEBHOOK_URL}
+      # The docker CLI respects this — no direct socket mount needed.
+      - DOCKER_HOST=tcp://docker_socket_proxy:2375
     ports:
       - "3080:3080"
     healthcheck:
@@ -31,16 +55,17 @@ services:
     container_name: birdmug_portal_staging
     profiles: ["staging"]
     restart: "no"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    group_add:
-      - "111"
+    depends_on:
+      - docker_socket_proxy
+    networks:
+      - portal_net
     environment:
       - PORT=${PORT}
       - NODE_ENV=production
       - BIRDMUG_JWT_SECRET=${BIRDMUG_JWT_SECRET}
       - BUGFAIRY_URL=${BUGFAIRY_URL}
       - MATTERMOST_WEBHOOK_URL=${MATTERMOST_WEBHOOK_URL}
+      - DOCKER_HOST=tcp://docker_socket_proxy:2375
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3080/health',(r)=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"]
       interval: 10s
@@ -54,12 +79,15 @@ services:
     container_name: birdmug_portal_dev
     profiles: ["dev"]
     restart: unless-stopped
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - docker_socket_proxy
+    networks:
+      - portal_net
     environment:
       - PORT=${PORT}
       - BIRDMUG_JWT_SECRET=${BIRDMUG_JWT_SECRET}
       - BUGFAIRY_URL=${BUGFAIRY_URL}
+      - DOCKER_HOST=tcp://docker_socket_proxy:2375
     ports:
       - "3081:3080"
     healthcheck:
@@ -68,3 +96,7 @@ services:
       timeout: 5s
       retries: 3
       start_period: 15s
+
+networks:
+  portal_net:
+    driver: bridge


### PR DESCRIPTION
Closes #3. Introduces `tecnativa/docker-socket-proxy` in front of `/var/run/docker.sock`. Only CONTAINERS/IMAGES/INFO read endpoints are allowed through; writes + EXEC + volumes are denied. Portal services switch to `DOCKER_HOST=tcp://docker_socket_proxy:2375` and no longer mount the raw socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)