### PR TITLE
fix(compose): drive staging+dev port from $PORT for parity with prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,9 @@ services:
       - MATTERMOST_WEBHOOK_URL=${MATTERMOST_WEBHOOK_URL}
       - DOCKER_HOST=tcp://docker_socket_proxy:2375
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3080/health',(r)=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"]
+      # Read PORT from runtime env so the probe always matches what Node is
+      # bound to. See prod healthcheck for the 2026-04-28 outage history.
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:'+process.env.PORT+'/health',(r)=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -102,9 +104,9 @@ services:
       - BUGFAIRY_URL=${BUGFAIRY_URL}
       - DOCKER_HOST=tcp://docker_socket_proxy:2375
     ports:
-      - "3081:3080"
+      - "3081:${PORT}"
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3080/health',(r)=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:'+process.env.PORT+'/health',(r)=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
Prod was hotfixed to read `process.env.PORT` at runtime in PR #14. Staging + dev still hardcoded 3080. They worked by accident (Doppler `PORT=3080`) but would break the same way prod did the moment Doppler changes.

This becomes load-bearing because [toshi-infra#2](https://github.com/falkensteink/toshi-infra/pull/2) just landed — staged deploys actually run the staging container now (they were silently no-oping for weeks), so brittleness in `portal-staging`'s healthcheck would now produce real failures.

## Changes
- `portal-staging` healthcheck → `process.env.PORT`
- `portal-dev` healthcheck → `process.env.PORT`
- `portal-dev` port mapping `3081:3080` → `3081:\${PORT}`

## Test plan
Watching the merge for the moment of truth: the staged-deploy script should now actually bring up `birdmug_portal_staging`, healthcheck it inside the container, and only promote to prod once it's green.

- [x] `npm test` 10/10 pass
- [ ] Confirm `birdmug_portal_staging` container is created during the deploy (was nonexistent before today)
- [ ] Confirm `BirdMug-Portal_staged_*.log` shows "Staging health check PASSED"
- [ ] Confirm prod is recreated and healthy after promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)