### PR TITLE
ci: gate PRs with compose-lint + verify deploy outcome via health URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,8 @@ jobs:
       node-version: "20"
       has-tests: true
       test-command: "npm test"
+
+  compose-lint:
+    uses: falkensteink/ci-templates/.github/workflows/compose-lint.yml@main
+    with:
+      compose-files: "docker-compose.yml"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,5 +20,11 @@ jobs:
     with:
       repo-name: BirdMug-Portal
       branch: main
+      # Poll the public health URL after triggering. Without this, the
+      # workflow goes green on toshi-bot's webhook ack — i.e. when the
+      # deploy is *queued*, not when it's done. That gap masked the
+      # 2026-04-28 outage; the run reported success while staged-deploy
+      # had silently died on a stale infinite-recursion bug.
+      health-url: https://birdmug.com/health
     secrets:
       TOSHI_DEPLOY_SECRET: ${{ secrets.TOSHI_DEPLOY_SECRET }}


### PR DESCRIPTION
## Summary
Wire two new pipeline strengtheners (both shipped in `falkensteink/ci-templates` today):

1. **compose-lint job in `ci.yml`** — calls [compose-lint.yml](https://github.com/falkensteink/ci-templates/blob/main/.github/workflows/compose-lint.yml). Catches R001–R005 (restart-storm + healthcheck presence + heavy-runner caps) plus the new **R006 \$PORT-coherence rule** ([ci-templates#4](https://github.com/falkensteink/ci-templates/pull/4)). The exact compose pattern that broke prod yesterday would now block the PR at lint time.

2. **`health-url` input in `deploy.yml`** — the deploy workflow now polls `https://birdmug.com/health` after triggering toshi-bot. Requires 3 consecutive 200s within 10 min before reporting success ([ci-templates#5](https://github.com/falkensteink/ci-templates/pull/5)). Closes the gap where Actions reported green on the toshi-bot webhook ack alone — exactly what masked yesterday's outage.

## Verification
- `compose-lint / §3 compose lint` already green on this branch
- Outcome polling will be exercised on the next merge to main; expected to pass at +~150s

## Test plan
- [x] CI run on this branch shows compose-lint passes
- [ ] After merge: deploy run polls health URL and goes green only once the deploy actually lands
- [ ] Future regressions of yesterday's bug class blocked at PR (compose-lint) and at deploy (health-URL outcome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)