### PR TITLE
fix(env): namespace Portal vars for birdmug-studios consolidation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,15 +43,23 @@ services:
     networks:
       - portal_net
     environment:
-      - PORT=${PORT}
+      # Portal-namespaced env from birdmug-studios/prd. PORT and
+      # MATTERMOST_WEBHOOK_URL are passed BOTH as PORTAL_* (what server.js
+      # reads) and as the legacy unprefixed names (what the compose-level
+      # healthcheck `process.env.PORT` and the host-port mapping below
+      # consume). Both alias to the same Doppler-side value so they can't
+      # drift; the legacy aliases drop in a follow-up PR once tests confirm.
+      - PORTAL_PORT=${PORTAL_PORT}
+      - PORT=${PORTAL_PORT}
+      - PORTAL_MATTERMOST_WEBHOOK_URL=${PORTAL_MATTERMOST_WEBHOOK_URL}
+      - MATTERMOST_WEBHOOK_URL=${PORTAL_MATTERMOST_WEBHOOK_URL}
       - NODE_ENV=production
       - BIRDMUG_JWT_SECRET=${BIRDMUG_JWT_SECRET}
       - BUGFAIRY_URL=${BUGFAIRY_URL}
-      - MATTERMOST_WEBHOOK_URL=${MATTERMOST_WEBHOOK_URL}
       # The docker CLI respects this — no direct socket mount needed.
       - DOCKER_HOST=tcp://docker_socket_proxy:2375
     ports:
-      - "3080:${PORT}"
+      - "3080:${PORTAL_PORT}"
     healthcheck:
       # Read PORT from the container's env at runtime so the probe always
       # matches what Node is actually bound to. Hardcoding here is what
@@ -74,11 +82,19 @@ services:
     networks:
       - portal_net
     environment:
-      - PORT=${PORT}
+      # Portal-namespaced env from birdmug-studios/prd. PORT and
+      # MATTERMOST_WEBHOOK_URL are passed BOTH as PORTAL_* (what server.js
+      # reads) and as the legacy unprefixed names (what the compose-level
+      # healthcheck `process.env.PORT` and the host-port mapping below
+      # consume). Both alias to the same Doppler-side value so they can't
+      # drift; the legacy aliases drop in a follow-up PR once tests confirm.
+      - PORTAL_PORT=${PORTAL_PORT}
+      - PORT=${PORTAL_PORT}
+      - PORTAL_MATTERMOST_WEBHOOK_URL=${PORTAL_MATTERMOST_WEBHOOK_URL}
+      - MATTERMOST_WEBHOOK_URL=${PORTAL_MATTERMOST_WEBHOOK_URL}
       - NODE_ENV=production
       - BIRDMUG_JWT_SECRET=${BIRDMUG_JWT_SECRET}
       - BUGFAIRY_URL=${BUGFAIRY_URL}
-      - MATTERMOST_WEBHOOK_URL=${MATTERMOST_WEBHOOK_URL}
       - DOCKER_HOST=tcp://docker_socket_proxy:2375
     healthcheck:
       # Read PORT from runtime env so the probe always matches what Node is
@@ -100,12 +116,13 @@ services:
     networks:
       - portal_net
     environment:
-      - PORT=${PORT}
+      - PORTAL_PORT=${PORTAL_PORT}
+      - PORT=${PORTAL_PORT}
       - BIRDMUG_JWT_SECRET=${BIRDMUG_JWT_SECRET}
       - BUGFAIRY_URL=${BUGFAIRY_URL}
       - DOCKER_HOST=tcp://docker_socket_proxy:2375
     ports:
-      - "3081:${PORT}"
+      - "3081:${PORTAL_PORT}"
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:'+process.env.PORT+'/health',(r)=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"]
       interval: 30s

--- a/server.js
+++ b/server.js
@@ -8,10 +8,18 @@ const { logger, requestLogger } = require('./json-logger');
 const app = express();
 app.set('trust proxy', 1);
 app.use(requestLogger);
-const PORT = process.env.PORT || 3080;
+// PORT and MATTERMOST_WEBHOOK_URL are namespaced to PORTAL_* because
+// birdmug-studios is shared with Spellstorm/SCS/DOD/bug-fairy/ai-pulse.
+// bug-fairy reads MATTERMOST_WEBHOOK_URL with a different value (its
+// own chat channel), so an unprefixed name would clobber its routing.
+// PORTAL_PORT keeps the pattern symmetric and avoids future collisions.
+// Old names kept as fallback for the cutover window — deletes can land
+// in a follow-up PR once we're confident no env still ships PORT/etc.
+const PORT = process.env.PORTAL_PORT || process.env.PORT || 3080;
 const JWT_SECRET = process.env.BIRDMUG_JWT_SECRET || '';
 const BUGFAIRY_URL = process.env.BUGFAIRY_URL || 'https://bugs.birdmug.com';
-const MATTERMOST_WEBHOOK_URL = process.env.MATTERMOST_WEBHOOK_URL || '';
+const MATTERMOST_WEBHOOK_URL =
+  process.env.PORTAL_MATTERMOST_WEBHOOK_URL || process.env.MATTERMOST_WEBHOOK_URL || '';
 const PUBLIC_DIR = path.join(__dirname, 'public');
 
 // Explicit opt-in for running locally without auth. Never set this in prod.


### PR DESCRIPTION
## Summary

Pairs with toshi-infra PR #4. Moves BirdMug-Portal off its dedicated `birdmug-portal` Doppler project onto the shared `birdmug-studios` config, joining Spellstorm/SCS/DOD/bug-fairy/ai-pulse.

bug-fairy already reads `MATTERMOST_WEBHOOK_URL` from studios with its own chat channel, so an unprefixed migration would clobber its routing. We namespace Portal's conflicting keys to `PORTAL_*` instead.

## Doppler migration (done, hash-verified)

| birdmug-portal/prd | birdmug-studios/prd | conflict resolution |
|---|---|---|
| `PORT` | `PORTAL_PORT` | namespaced |
| `MATTERMOST_WEBHOOK_URL` | `PORTAL_MATTERMOST_WEBHOOK_URL` | namespaced |
| `BUGFAIRY_URL` | `BUGFAIRY_URL` | no conflict, kept |
| `BIRDMUG_JWT_SECRET` | (already there, matched) | no migration needed |

## Code changes

- `server.js`: prefer `PORTAL_PORT` and `PORTAL_MATTERMOST_WEBHOOK_URL`, fall back to legacy names for the cutover window
- `docker-compose.yml`: pass `PORTAL_*` AND the unprefixed aliases through to the container so the existing `process.env.PORT` healthcheck and `${PORTAL_PORT}` host-port mapping both work
- Aliases drop in a follow-up PR after soak

## Pairs with
- toshi-infra PR #4 (flips `DOPPLER_PROJECT["BirdMug-Portal"]` from `birdmug-portal` → `birdmug-studios`)

## Test plan
- [ ] Merge AFTER toshi-infra#4 (or together — they need to land in the same deploy)
- [ ] On Toshi, redeploy via `doppler run --project=birdmug-studios --config=prd -- docker compose --profile prod up -d --force-recreate`
- [ ] Verify the container has `PORTAL_PORT` set: `docker exec birdmug_portal printenv PORTAL_PORT`
- [ ] Verify Portal serves at https://birdmug.com (loads, login works)
- [ ] After soak: archive the `birdmug-portal` Doppler project

🤖 Generated with [Claude Code](https://claude.com/claude-code)