### PR TITLE
hardening: pin images + extend .dockerignore (L033, L040)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,28 @@
+# Secrets — never bake into images (Arbiter L040)
+.env
+.env.*
+*.pem
+*.key
+credentials*.json
+secrets*.json
+
+# VCS
 .git
-node_modules
-*.md
 .gitignore
+
+# Node
+node_modules/
+npm-debug.log*
+
+# Tests + docs (build context = .; image only needs server.js + public/)
+test/
+*.md
+
+# IDE / OS
+.vscode/
+.idea/
+*.swp
+.DS_Store
+
+# Project housekeeping
+memory/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
   # env vars, etc. docker-socket-proxy (tecnativa) whitelists only what's
   # needed: `docker ps` -equivalent calls over an HTTP shim, read-only.
   docker_socket_proxy:
-    image: tecnativa/docker-socket-proxy:latest
+    # Pinned per Arbiter L033. Bumps go through Dependabot per L027.
+    image: tecnativa/docker-socket-proxy:0.3
     container_name: portal_docker_socket_proxy
     restart: on-failure:3
     environment:
@@ -34,7 +35,10 @@ services:
   # ── Production ──
   portal-prod:
     build: .
-    image: birdmug-portal:latest
+    # Locally-built tag — `:current` (not `:latest`) per Arbiter L033.
+    # The Dockerfile is what changes; the tag is just a friendly local
+    # name for compose to reference across services.
+    image: birdmug-portal:current
     container_name: birdmug_portal
     profiles: ["prod"]
     restart: on-failure:3


### PR DESCRIPTION
Closes #23 (L040). Image pin (L033) was filed as a separate issue group but BirdMug-Portal didn't get an L033 issue — bundling here anyway since both apply to the same compose file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)