### PR TITLE
fix(/api/apps): tolerate Docker socket outages without dropping the registry [skip ci]

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -226,10 +226,14 @@ async function loadApps() {
     const data = await response.json();
     const apps = (data.apps || []).filter((app) => app.category === "app");
     const infra = (data.apps || []).filter((app) => app.category !== "app");
-    const totalOnline = data.apps ? data.apps.filter((app) => app.up).length : 0;
+    // up is now nullable: true | false | null. Only count `true` as online;
+    // null ("Docker unreachable, can't tell") is its own state, not offline.
+    const totalOnline = data.apps ? data.apps.filter((app) => app.up === true).length : 0;
     const totalServices = data.apps ? data.apps.length : 0;
 
-    if (data.error) {
+    if (data.docker_unreachable) {
+      showError("Docker socket unreachable — registry is current, but live status is unknown.");
+    } else if (data.error) {
       showError(data.error);
     } else {
       hideError();
@@ -237,7 +241,7 @@ async function loadApps() {
 
     els.appCards.innerHTML = renderServiceCards(apps, "Products");
     els.infraCards.innerHTML = renderServiceCards(infra, "Infrastructure");
-    renderHeroSignals(apps, infra, totalOnline, totalServices);
+    renderHeroSignals(apps, infra, totalOnline, totalServices, Boolean(data.docker_unreachable));
   } catch (error) {
     showError(`Error: ${error.message}`);
     els.heroInlineStatus.textContent = "Registry unavailable";
@@ -247,13 +251,20 @@ async function loadApps() {
   }
 }
 
-function renderHeroSignals(apps, infra, totalOnline, totalServices) {
-  const appOnline = apps.filter((app) => app.up).length;
-  const infraOnline = infra.filter((app) => app.up).length;
-  const heroClass = totalOnline === totalServices ? "ok" : totalOnline > 0 ? "warn" : "down";
+function renderHeroSignals(apps, infra, totalOnline, totalServices, dockerUnreachable = false) {
+  const appOnline = apps.filter((app) => app.up === true).length;
+  const infraOnline = infra.filter((app) => app.up === true).length;
+  // When Docker is unreachable, every app's `up` is null; don't paint the
+  // hero red — that would imply everything is down, which we can't actually
+  // confirm. Show "warn" + a status string that names the cause.
+  const heroClass = dockerUnreachable
+    ? "warn"
+    : totalOnline === totalServices ? "ok" : totalOnline > 0 ? "warn" : "down";
 
   els.heroInlineStatus.className = `hero-inline-status ${heroClass}`;
-  els.heroInlineStatus.textContent = `${totalOnline}/${totalServices} services online`;
+  els.heroInlineStatus.textContent = dockerUnreachable
+    ? `${totalServices} services tracked · status unknown`
+    : `${totalOnline}/${totalServices} services online`;
 
   els.heroSignalGrid.innerHTML = [
     renderSignalCard("Registry", String(totalServices), "Tracked services"),
@@ -282,8 +293,10 @@ function renderServiceCards(apps, groupLabel) {
     const hasUrl = Boolean(app.url);
     const url = hasUrl ? safeUrl(app.url) : "";
     const host = hasUrl ? getHostname(app.url) : "Internal service";
-    const statusClass = app.up ? "ok" : "down";
-    const statusText = app.up ? "Online" : "Degraded";
+    // Three states: true → Online (green), false → Degraded (red),
+    // null → Unknown (grey, "Docker unreachable, can't tell").
+    const statusClass = app.up === true ? "ok" : app.up === false ? "down" : "unknown";
+    const statusText = app.up === true ? "Online" : app.up === false ? "Degraded" : "Unknown";
 
     return `
       <article class="service-card">

--- a/public/styles.css
+++ b/public/styles.css
@@ -468,6 +468,17 @@ h3 {
   background: var(--red-soft);
 }
 
+/* "Unknown" — Docker socket unreachable, /api/apps couldn't compute up.
+ * Grey rather than red because the registry IS valid; we just can't
+ * answer "is it currently running?" Clearly signals "we don't know"
+ * instead of falsely implying the app is down. */
+.hero-inline-status.unknown,
+.service-state.unknown,
+.project-status-pill.unknown {
+  color: #9aa0a6;
+  background: rgba(154, 160, 166, 0.12);
+}
+
 .hero-signal-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/server.js
+++ b/server.js
@@ -319,32 +319,45 @@ app.get('/', (req, res) => res.sendFile(path.join(PUBLIC_DIR, 'index.html')));
 // Health check
 app.get('/health', (req, res) => res.json({ status: 'ok' }));
 
-// Public: app status (green/red only, no container details).
+// Public: app status (green/red/unknown, no container details).
 // Services without a public URL (e.g. batch jobs like cz_audiobook) are
 // excluded from the public index but still appear in /api/status for operators.
+//
+// Docker socket-proxy outages (transient dockerd hiccups, restart windows,
+// proxy container down) used to swap the response for `apps: []` + 503,
+// which then tripped Arbiter L022's `every project listed in /api/apps`
+// check against every fleet project — see falkensteink/BirdMug-Portal#19.
+// "Is this app deployed?" and "is this app currently up?" are two different
+// questions; the registry is static + in-process and always answerable, so
+// we always return it. `up` becomes nullable: true | false | null
+// ("unknown — Docker unreachable"), and `docker_unreachable: true` is set
+// at the top level so the frontend can render a banner.
 app.get('/api/apps', async (req, res) => {
+  let containerMap = null;
   try {
-    const containerMap = await getContainerMap();
-    const apps = Object.entries(APP_REGISTRY)
-      .filter(([, app]) => Boolean(app.url))
-      .map(([id, app]) => {
-        const primaryStatus = containerMap[app.primary] || '';
-        const up = primaryStatus.toLowerCase().startsWith('up');
-        const entry = {
-          id,
-          name: app.name,
-          description: app.description,
-          url: app.url,
-          category: app.category,
-          up,
-        };
-        if (app.itch) entry.itch = app.itch;
-        return entry;
-      });
-    res.json({ apps, ts: Date.now() });
+    containerMap = await getContainerMap();
   } catch {
-    res.status(503).json({ apps: [], error: 'Cannot reach Docker', ts: Date.now() });
+    // Docker unreachable — registry is still valid, just can't compute up.
   }
+  const apps = Object.entries(APP_REGISTRY)
+    .filter(([, app]) => Boolean(app.url))
+    .map(([id, app]) => {
+      const entry = {
+        id,
+        name: app.name,
+        description: app.description,
+        url: app.url,
+        category: app.category,
+        up: containerMap === null
+          ? null
+          : (containerMap[app.primary] || '').toLowerCase().startsWith('up'),
+      };
+      if (app.itch) entry.itch = app.itch;
+      return entry;
+    });
+  const body = { apps, ts: Date.now() };
+  if (containerMap === null) body.docker_unreachable = true;
+  res.json(body);
 });
 
 // Admin: full server status + per-container details

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -125,14 +125,47 @@ describe('GET /', () => {
 });
 
 describe('GET /api/apps', () => {
-  it('returns JSON with apps array and ts', async () => {
-    // Docker is not running in test, so this will return 503
-    // which is still a valid response shape
+  it('returns 200 with apps array and ts even when Docker is unreachable', async () => {
+    // Docker is not running in test, so getContainerMap throws.
+    // After the #19 fix, /api/apps catches that and returns the registry
+    // anyway with `up: null` per app + `docker_unreachable: true` flagged.
+    // 503 is no longer a valid response shape on this route.
     const res = await request('/api/apps');
-    // Either 200 (docker available) or 503 (docker unavailable)
-    assert.ok([200, 503].includes(res.status));
+    assert.equal(res.status, 200);
     assert.ok(Array.isArray(res.body.apps));
     assert.ok(typeof res.body.ts === 'number');
+  });
+
+  it('returns docker_unreachable: true when Docker is unreachable', async () => {
+    // No Docker socket in test → the docker-unreachable branch always fires.
+    const res = await request('/api/apps');
+    assert.equal(res.body.docker_unreachable, true);
+  });
+
+  it('returns the full registry (non-empty) on Docker outage', async () => {
+    // The docker-outage failure mode used to swap the response for
+    // `apps: []`. After #19 the registry comes through regardless.
+    const res = await request('/api/apps');
+    assert.ok(res.body.apps.length > 0,
+      'expected non-empty registry even when Docker is unreachable');
+  });
+
+  it('sets up: null on every app when Docker is unreachable', async () => {
+    const res = await request('/api/apps');
+    for (const app of res.body.apps) {
+      assert.equal(app.up, null,
+        `app ${app.id} should have up:null when Docker is unreachable, got ${app.up}`);
+    }
+  });
+
+  it('still includes the standard fields for every app', async () => {
+    const res = await request('/api/apps');
+    for (const app of res.body.apps) {
+      assert.ok(app.id, 'id is required');
+      assert.ok(app.name, 'name is required');
+      assert.ok(app.url, 'url is required (apps without url are filtered)');
+      assert.ok(app.category, 'category is required');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

\`/api/apps\` used to swap the whole response for \`apps: []\` + HTTP 503 on any \`getContainerMap()\` failure. The registry is static + in-process and fully answerable even with Docker down — the only thing actually unknown is the live \`up\` field. Throwing the registry away meant:

1. **Arbiter L022** (every project listed in \`/api/apps\`) opened a false-positive warning against **every** fleet project on every transient Docker outage. The 2026-04-29 nightly was exactly this: NPC-PM#29 and the L022 receipts on every other repo were all this failure mode.
2. The public hub showed \"Registry unavailable\" during what was actually a 5-second proxy hiccup.

## After this PR

- \`/api/apps\` always returns the registry. \`up\` becomes nullable: \`true | false | null\` (\"Docker unreachable, can't tell\").
- \`docker_unreachable: true\` flag at the top level lets the frontend render a banner without inferring it from a missing field.
- Frontend renders three states: green \"Online\", red \"Degraded\", grey \"Unknown\".

## Test plan

- [x] 4 new test assertions cover the docker-down branch: 200 (not 503), registry non-empty, \`docker_unreachable: true\`, \`up: null\` per entry.
- [x] \`npm test\` — all 14 tests pass locally.
- [ ] After merge: visit \`https://birdmug.com\` during a docker_socket_proxy restart and verify the banner + grey dots show instead of an empty page.
- [ ] Next nightly Arbiter run no longer false-flags L022 against every fleet project during a transient Docker hiccup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)